### PR TITLE
allow finetuning on 774M

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -148,7 +148,7 @@ def finetune(sess,
     See that file for parameter definitions.
     """
 
-    assert model_name not in ['774M', '1558M'], "Currently, modern GPUs cannot finetune the 774M GPT-2 model or larger."
+    assert model_name not in ['1558M'], "Currently, modern GPUs cannot finetune the 1558M GPT-2 model or larger."
 
     SAMPLE_DIR = 'samples'
 


### PR DESCRIPTION
Currently there is an assert statement checking that model_name doesn't equal 774M. This should be removed if the changes in finetuning_774M do indeed work.